### PR TITLE
Clear data placeholder text when any encounter data exists

### DIFF
--- a/src/lib/components/pokemon-selector.svelte
+++ b/src/lib/components/pokemon-selector.svelte
@@ -270,6 +270,7 @@
   }
 
   $: gray = NuzlockeGroups.Unavailable.includes(status?.id)
+  $: hasData = !!(selected || nickname || status || nature)
 </script>
 
 <SettingsWrapper id="nickname-clause" let:setting={nicknames}>
@@ -397,7 +398,7 @@
         rounded
         bind:value={nickname}
         name="{location} Nickname"
-        placeholder="Nickname"
+        placeholder={hasData ? '' : 'Nickname'}
         className="col-span-2 {!selected || hidden || status?.id === 4
           ? 'hidden sm:block'
           : ''}"
@@ -425,7 +426,7 @@
           bind:selected={status}
           id="{location} Status"
           name="{location} Status"
-          placeholder="Status"
+          placeholder={hasData ? '' : 'Status'}
           class="{!selected || hidden ? 'hidden sm:block' : ''} {status?.id ===
           4
             ? 'col-span-2 sm:col-span-1'
@@ -466,7 +467,7 @@
       bind:selected={nature}
       id="{location} Nature"
       name="{location} Nature"
-      placeholder="Nature"
+      placeholder={hasData ? '' : 'Nature'}
       class="col-span-1 {!selected || status?.id === 4 || hidden
         ? 'hidden sm:block'
         : ''}"


### PR DESCRIPTION
When any encounter is selected in an encounter row, the "Nickname", "Nature", and "Status" placeholder text now clears. This helps distinguish active rows from empty ones via the reactive hasData check. "Find encounter" is left alone since it probably always makes sense to have placeholder text here.

First of several PRs to implement new features! Happy to chat on Discord